### PR TITLE
Fix failing tests

### DIFF
--- a/extra/specs/analytics.spec.js
+++ b/extra/specs/analytics.spec.js
@@ -12,23 +12,25 @@ define([
     'require',
     '{angular}/angular',
     '{angular-mocks}/angular-mocks',
-    '{w20-extra}/modules/analytics'
+    '{w20-extra}/modules/analytics',
+    '{w20-extra}/modules/providers/piwik-config'
 ], function (require, angular) {
     'use strict';
 
     describe('The analytics module', function () {
         beforeEach(function () {
             angular.mock.module('W20ExtraAnalytics');
+            angular.mock.module('W20ExtraPiwik');
         });
 
         it('should require the appropriate angulartics support for piwik as defined in the test fragment manifest', function () {
-            var angularticsPiwikIsDefined = require.defined('{angulartics}/angulartics-piwik');
-            expect(angularticsPiwikIsDefined).toBe(true);
+            var angularticsPiwikIsDefined = require.specified('{angulartics}/angulartics-piwik');
+            expect(angularticsPiwikIsDefined).toBeDefined();
         });
 
         it('should require the w20 piwik config support if the \'settings\' property is set in the manifest (it is set in the test fragment)', function() {
-            var w20PiwikConfigIsDefined = require.defined('{w20-extra}/modules/providers/piwik-config');
-            expect(w20PiwikConfigIsDefined).toBe(true);
+            var w20PiwikConfigIsDefined = require.specified('{w20-extra}/modules/providers/piwik-config');
+            expect(w20PiwikConfigIsDefined).toBeDefined();
         });
 
     });


### PR DESCRIPTION
Fix #17 

Tests were failing sometimes because of requirejs lag when calling require.defined, this PR replace it with require.specified.  