### PR TITLE
Added alias declaration for api path

### DIFF
--- a/core/modules/hypermedia.js
+++ b/core/modules/hypermedia.js
@@ -718,7 +718,7 @@ define([
     function getHost(url) {
         var uri = window.document.createElement('a');
 
-        if (isAbsolute(url)) {
+        if (isAbsolute(url) || startWithSlash(url)) {
 
             uri.href = url;
 
@@ -776,16 +776,17 @@ define([
                  */
                 function prefixHomeResourcesWithApiHost(definition, apiHost) {
 
+                    if (!apiHost) {
+
+                        return definition;
+                    }
+
                     var prefixWithApiHost = function (url, host) {
 
                         return toAbsoluteUrl(url, stripTrailingSlash(host));
 
                     };
 
-                    if (!apiHost) {
-
-                        return definition;
-                    }
 
                     if (definition.href) {
 
@@ -859,7 +860,7 @@ define([
 
                     api[apiName] = {};
 
-                    apiHost = getHost(toAbsoluteUrl(apiUrl));
+                    apiHost = getHost(toAbsoluteUrl(apiUrl, ''));
 
                     apiPromises.push(
                         $http({ method: 'GET', url: apiUrl, headers: { 'accept': 'application/json-home' } })

--- a/core/w20-core.w20.json
+++ b/core/w20-core.w20.json
@@ -128,6 +128,10 @@
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
+                    "api": {
+                        "description": "Specify hypermedia api(s) entry point (exposed as json-home document)",
+                        "type": "object"
+                    },
                     "linksKey": {
                         "description": "Specify the links key of the resources (defaults to '_links')",
                         "type": "string"


### PR DESCRIPTION
Configuration can use aliases for api endpoints

```
"api": {
    "home": "/rest/",
    "coolApi": "http://www.apidomain.com/api",
    "other": "@home",
    "another": "@coolApi"
}
```

If @home is given alone 

```
"api": {
    "myApi": "@home",
}
```

It resolves to document protocol://hostname:port with '/rest/' appended.

Also added some internal refactoring of utility functions.