### PR TITLE
Replaced URI templates library

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,7 +32,7 @@
     "require-css": "0.1.8",
     "showdown": "1.2.1",
 
-    "uri.js": "1.15.1"
+    "uri-templates": "~0.1"
   },
   "devDependencies": {
     "angular-mocks": "1.3.16"

--- a/modules/hypermedia.js
+++ b/modules/hypermedia.js
@@ -14,7 +14,7 @@ define([
     'require',
 
     '{angular}/angular',
-    '{uri.js}/URITemplate',
+    '{uri-templates}/uri-templates',
 
     '{angular-resource}/angular-resource'
 
@@ -220,7 +220,7 @@ define([
                     }
                     else {
                         var url = new URITemplate(homeResource['href-template']);
-                        url = url.expand(parameters);
+                        url = url.fill(parameters);
                         return $resource(url, undefined, actions, options);
                     }
                 }
@@ -326,7 +326,7 @@ define([
                     // process the url and call the resources function with the given parameters
                     if (link.templated) {
                         url = new URITemplate(link[config.linksHrefKey]);
-                        url = url.expand(parameters);
+                        url = url.fill(parameters);
                         // set parameters to undefined since they are resolved by the uri template expansion,
                         // otherwise it will duplicate parameters
                         parameters = undefined;

--- a/w20-core.w20.json
+++ b/w20-core.w20.json
@@ -237,7 +237,7 @@
             "{requirejs-text}": "${components-path:bower_components}/requirejs-text",
             "{requirejs}": "${components-path:bower_components}/requirejs",
             "{require-css}": "${components-path:bower_components}/require-css",
-            "{uri.js}": "${components-path:bower_components}/uri.js/src",
+            "{uri-templates}": "${components-path:bower_components}/uri-templates",
             "jquery": "${components-path:bower_components}/jquery/dist/jquery",
             "{jgrowl}": "${components-path:bower_components}/jgrowl",
             "showdown": "${components-path:bower_components}/showdown/dist/showdown",
@@ -260,9 +260,6 @@
             },
             "{tv4}/tv4": {
                 "exports": "tv4"
-            },
-            "{uri.js}/URITemplate": {
-                "deps": ["{uri.js}/URI"]
             },
             "{jgrowl}/jquery.jgrowl":[
                 "jquery"


### PR DESCRIPTION
Fix #45 

URI templates resolution was handled by URI.js which has problematic packaging (its minified distribution is actually different than the non minified version). It has been replaced with another RFC 6570 (URI templates) compliant library ("uri-templates").